### PR TITLE
Sprites

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Have a look in `/example` for some more interesting ones. Be sure to run the exa
 _ggl_ is split into 4 packages:
 
  - **window** handles creation of windows and rendering to them.
- - **geom** contains structs for various shapes and other maths things.
+ - **geom** contains structs for various shapes and other things.
  - **colour** contains the colour struct, since it didn't really fit in anywhere else.
  - **loader** loads assets (currently only textures, but in the future there will be more).
 
@@ -51,13 +51,13 @@ Currently implemented:
  - Fast, GPU accelerated rendering
  - Event handling (raw SDL events)
  - Asset loading
+ - Sprites
 
 What isn't implemented yet, but will be soon:
 
  - **Documentation**
  - An event wrapper type
  - Store currently pressed keys and mouse buttons in the window for querying
- - Sprites
  - Sounds
  - Text rendering, fonts
 

--- a/example/assets.go
+++ b/example/assets.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"github.com/Zac-Garby/ggl/geom"
 	"github.com/Zac-Garby/ggl/loader"
 	"github.com/Zac-Garby/ggl/window"
-	"github.com/veandco/go-sdl2/sdl"
 )
 
 func main() {
@@ -20,30 +20,28 @@ func main() {
 
 	load.MustLoad()
 	_, cat := load.MustGetTexture("cat", win.Renderer)
-	s, gopher := load.MustGetTexture("gopher", win.Renderer)
 
-	x := -float64(s.W)
-	angle := 0.0
+	gopher, err := geom.SpriteFromAsset("gopher", load, win.Renderer, 0, 0)
+	if err != nil {
+		panic(err)
+	}
+
+	gopher.Y = 300 - gopher.Height/2
+	gopher.X = -gopher.Width / 2
 
 	win.Render = func() {
-		win.Renderer.Copy(cat, nil, nil)
-
-		win.Renderer.CopyEx(gopher, nil, &sdl.Rect{
-			X: int32(x),
-			Y: 300 - s.H/2,
-			W: s.W,
-			H: s.H,
-		}, angle, nil, sdl.FLIP_NONE)
+		win.Texture(cat, 0, 0, 800, 600)
+		win.Sprite(gopher)
 	}
 
 	win.Update = func(dt float64) {
-		x += 150 * dt
+		gopher.Move(150*dt, 0)
 
-		if x-50 > 800 {
-			x = -float64(s.W) - 50
+		if gopher.X-50 > 800 {
+			gopher.X = -float64(gopher.Width) - 50
 		}
 
-		angle += 90 * dt
+		gopher.Rotate(90 * dt)
 	}
 
 	win.Loop()

--- a/geom/sprite.go
+++ b/geom/sprite.go
@@ -24,7 +24,10 @@ func New(tex *sdl.Texture, x, y, width, height float64) *Sprite {
 	}
 }
 
-// FromAsset creates a new sprite
+// FromAsset creates a new sprite by loading
+// the named asset from the loader. An error
+// will only be returned from the GetTexture
+// call.
 func FromAsset(name string, ld *loader.Loader, rend *sdl.Renderer, x, y float64) (*Sprite, error) {
 	surf, tex, err := ld.GetTexture(name, rend)
 	if err != nil {

--- a/geom/sprite.go
+++ b/geom/sprite.go
@@ -12,9 +12,9 @@ type Sprite struct {
 	Texture *sdl.Texture
 }
 
-// New creates a new sprite with the given
+// NewSprite creates a new sprite with the given
 // parameters.
-func New(tex *sdl.Texture, x, y, width, height float64) *Sprite {
+func NewSprite(tex *sdl.Texture, x, y, width, height float64) *Sprite {
 	return &Sprite{
 		X:       x,
 		Y:       y,
@@ -24,11 +24,11 @@ func New(tex *sdl.Texture, x, y, width, height float64) *Sprite {
 	}
 }
 
-// FromAsset creates a new sprite by loading
+// SpriteFromAsset creates a new sprite by loading
 // the named asset from the loader. An error
 // will only be returned from the GetTexture
 // call.
-func FromAsset(name string, ld *loader.Loader, rend *sdl.Renderer, x, y float64) (*Sprite, error) {
+func SpriteFromAsset(name string, ld *loader.Loader, rend *sdl.Renderer, x, y float64) (*Sprite, error) {
 	surf, tex, err := ld.GetTexture(name, rend)
 	if err != nil {
 		return nil, err

--- a/geom/sprite.go
+++ b/geom/sprite.go
@@ -1,0 +1,105 @@
+package geom
+
+import "github.com/veandco/go-sdl2/sdl"
+import "github.com/Zac-Garby/ggl/loader"
+
+// A Sprite is essentially a textured Spriteangle.
+type Sprite struct {
+	X, Y    float64
+	Width   float64
+	Height  float64
+	Angle   float64
+	Texture *sdl.Texture
+}
+
+// New creates a new sprite with the given
+// parameters.
+func New(tex *sdl.Texture, x, y, width, height float64) *Sprite {
+	return &Sprite{
+		X:       x,
+		Y:       y,
+		Width:   width,
+		Height:  height,
+		Texture: tex,
+	}
+}
+
+// FromAsset creates a new sprite
+func FromAsset(name string, ld *loader.Loader, rend *sdl.Renderer, x, y float64) (*Sprite, error) {
+	surf, tex, err := ld.GetTexture(name, rend)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Sprite{
+		X:       x,
+		Y:       y,
+		Width:   float64(surf.W),
+		Height:  float64(surf.H),
+		Texture: tex,
+	}, nil
+}
+
+// Move moves a Sprite by (x, y).
+func (r *Sprite) Move(x, y float64) {
+	r.X += x
+	r.Y += y
+}
+
+// Center sets the center of the Sprite
+// to (x, y).
+func (r *Sprite) Center(x, y float64) {
+	r.X = x - r.Width/2
+	r.Y = x - r.Height/2
+}
+
+// Left returns the x-ordinate of the
+// left side of the Sprite.
+func (r *Sprite) Left() float64 {
+	return r.X
+}
+
+// Right returns the x-ordinate of the
+// right side of the Sprite.
+func (r *Sprite) Right() float64 {
+	return r.X + r.Width
+}
+
+// Bottom returns the y-ordinate of the
+// bottom side of the Sprite.
+func (r *Sprite) Bottom() float64 {
+	return r.Y
+}
+
+// Top returns the y-ordinate of the
+// top side of the Sprite.
+func (r *Sprite) Top() float64 {
+	return r.Y + r.Height
+}
+
+// SDLRect returns an SDL Spriteangle
+// identicle to this Sprite. float64
+// fields are truncated to int32s.
+//
+func (r *Sprite) SDLRect() *sdl.Rect {
+	return &sdl.Rect{
+		X: int32(r.X),
+		Y: int32(r.Y),
+		W: int32(r.Width),
+		H: int32(r.Height),
+	}
+}
+
+// Rotate rotates the sprite by 'angle'
+// degrees.
+func (r *Sprite) Rotate(angle float64) {
+	r.Angle += angle
+
+	for r.Angle > 360 {
+		r.Angle -= 360
+	}
+
+	for r.Angle < 0 {
+		r.Angle += 360
+	}
+}

--- a/window/render.go
+++ b/window/render.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Zac-Garby/ggl/colour"
 	"github.com/Zac-Garby/ggl/geom"
 	"github.com/veandco/go-sdl2/gfx"
+	"github.com/veandco/go-sdl2/sdl"
 )
 
 // Fill causes shapes drawn after the call
@@ -111,6 +112,17 @@ func (w *Window) Polyline(verts []*geom.Vec) *Window {
 			w.Line(v, next)
 		}
 	}
+
+	return w
+}
+
+// Sprite draws a sprite on the window. Can be
+// chained.
+func (w *Window) Sprite(sprite *geom.Sprite) *Window {
+	w.Renderer.CopyEx(
+		sprite.Texture, nil, sprite.SDLRect(),
+		sprite.Angle, nil, sdl.FLIP_NONE,
+	)
 
 	return w
 }

--- a/window/render.go
+++ b/window/render.go
@@ -136,4 +136,6 @@ func (w *Window) Texture(tex *sdl.Texture, x, y, width, height float64) *Window 
 		W: int32(width),
 		H: int32(height),
 	})
+
+	return w
 }

--- a/window/render.go
+++ b/window/render.go
@@ -126,3 +126,14 @@ func (w *Window) Sprite(sprite *geom.Sprite) *Window {
 
 	return w
 }
+
+// Texture draws a texture directly to the window
+// without creating a sprite. Can be chained.
+func (w *Window) Texture(tex *sdl.Texture, x, y, width, height float64) *Window {
+	w.Renderer.Copy(tex, nil, &sdl.Rect{
+		X: int32(x),
+		Y: int32(y),
+		W: int32(width),
+		H: int32(height),
+	})
+}


### PR DESCRIPTION
You can now make sprites to render textures to the window, or render the texture directly (`window.Sprite()`, `window.Texture()`)